### PR TITLE
Add d.ts so TypeScript users can use it

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,76 @@
+/*
+  Types are taken from: @types/twemoji-parser
+  https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/twemoji-parser
+*/
+
+/**
+
+ * A simple library for identifying emoji entities within a string in order to render them as Twemoji.
+
+ * For example, this parser is used within the rendering flow for Tweets and other text on mobile.twitter.com
+
+ */
+
+
+export const TypeName = "emoji";
+
+
+export interface EmojiEntity {
+
+  /**
+
+   * @default 'emoji'
+
+   */
+
+  type: typeof TypeName;
+
+  text: string;
+
+  /**
+
+   * @default ''
+
+   */
+
+  url: string;
+
+  /**
+
+   * [startIndex: number, lastIndex: number]
+
+   */
+
+  indices: [number, number];
+
+}
+
+
+export interface ParsingOptions {
+
+  buildUrl?: ((codepoints: string, assetType: AssetType) => string) | undefined;
+
+  /**
+
+   * @default 'svg'
+
+   */
+
+  assetType?: AssetType | undefined;
+
+}
+
+
+export type AssetType = "png" | "svg";
+
+/**
+
+ * Parser takes a string and returns an array of the emoji entities it finds.
+
+ */
+
+export function parse(text: string, options?: ParsingOptions): EmojiEntity[];
+
+
+export function toCodePoints(unicodeSurrogates: string): string[];
+

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "version": "15.1.0",
   "description": "Parser for identifying Twemoji in text",
   "main": "dist/index.js",
+  "types": "index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# Problem

This package is made with JavaScript, but since DT or `.d.ts` does not exist, it was not possible to use it with TypeScript.
When I try to use it in TypeScript I get the following error:
```ts
Cannot find module '@twemoji/parser' or its corresponding type declarations.ts(2307)
```

# Solution

This PR adds [`index.d.ts`](https://github.com/k-kozika/twemoji-parser/blob/865054d8dc7b86aa40ee135f6c95a16e7bd4c10d/index.d.ts) and make changes to the `types` and `files` fields of [`package.json`](https://github.com/k-kozika/twemoji-parser/blob/865054d8dc7b86aa40ee135f6c95a16e7bd4c10d/package.json#L6-L11)

# Result

This adds a type definition, so it can be used more safely in TypeScript.
